### PR TITLE
changes dates to reflect COVID date

### DIFF
--- a/mgatour/season25/stats/mga_honours.html
+++ b/mgatour/season25/stats/mga_honours.html
@@ -21,10 +21,9 @@
                 <th>Season</th><th>Years</th><th>Winner</th><th>Points</th>
             </thead>
             <tbody>
-                <tr><td>25</td><td>2023/2024</td><td>Andrew Baldwin</td><td>38.29</td></tr>
-                <tr><td>24</td><td>2022/2023</td><td>David Archer</td><td>37.5</td></tr>
-                <tr><td>23</td><td>2021/2022</td><td>David Archer</td><td>37.5</td></tr>
-                <tr><td>22</td><td>2020/2021</td><td>Alan Hopkins</td><td>33.67</td></tr>
+                <tr><td>24</td><td>2023/2024</td><td>Andrew Baldwin</td><td>38.29</td></tr>
+                <tr><td>23</td><td>2022/2023</td><td>David Archer</td><td>37.5</td></tr>
+                <tr><td>22</td><td>2020/2022</td><td>Alan Hopkins</td><td>33.67</td></tr>
                 <tr><td>21</td><td>2019/2020</td><td>David Bingham</td><td>33.33</td></tr>
                 <tr><td>20</td><td>2018/2019</td><td>Chris Manning</td><td>34.73</td></tr>
                 <tr><td>19</td><td>2017/2018</td><td>Andrew Benson</td><td>33.5</td></tr>
@@ -58,10 +57,9 @@
             <th>Season</th><th>Years</th><th>Winner</th><th>Prize Winnings</th>
             </thead>
         <tbody>
-            <tr><td>25</td><td>2023/2024</td><td>Robert Thompson</td><td>£455,000</td></tr>
-            <tr><td>24</td><td>2022/2023</td><td>Robert Thompson</td><td>£348,750</td></tr>
-            <tr><td>23</td><td>2021/2022</td><td>Robert Thompson</td><td>£348,750</td></tr>
-            <tr><td>22</td><td>2020/2021</td><td>Robert Thompson</td><td>£151,250</td></tr>
+            <tr><td>24</td><td>2023/2024</td><td>Robert Thompson</td><td>£455,000</td></tr>
+            <tr><td>23</td><td>2022/2023</td><td>Robert Thompson</td><td>£348,750</td></tr>
+            <tr><td>22</td><td>2020/2022</td><td>Robert Thompson</td><td>£151,250</td></tr>
             <tr><td>21</td><td>2019/2020</td><td>David Rouse</td><td>£117,500</td></tr>
             <tr><td>20</td><td>2018/2019</td><td>David Rouse</td><td>£257,500</td></tr>
             <tr><td>19</td><td>2017/2018</td><td>Paul Carter</td><td>£223,750</td></tr>
@@ -96,10 +94,9 @@
                 <th>Season</th><th>Years</th><th>Winner</th><th>Fairway Hit</th>
             </thead>
         <tbody>
-                <tr><td>25</td><td>2023/2024</td><td>Andrew Benson</td><td>64.29&#37</td></tr>
-                <tr><td>24</td><td>2022/2023</td><td>Andrew Benson</td><td>54.17&#37</td></tr>
-                <tr><td>23</td><td>2021/2022</td><td>Andrew Benson</td><td>54.17&#37</td></tr>
-                <tr><td>22</td><td>2020/2021</td><td>John Press</td><td>48.08&#37</td></tr>
+                <tr><td>24</td><td>2024/2025</td><td>Andrew Benson</td><td>64.29&#37</td></tr>
+                <tr><td>23</td><td>2022/2023</td><td>Andrew Benson</td><td>54.17&#37</td></tr>
+                <tr><td>22</td><td>2020/2022</td><td>John Press</td><td>48.08&#37</td></tr>
                 <tr><td>21</td><td>2019/2020</td><td>David Bingham</td><td>51.22&#37</td></tr>
                 <tr><td>20</td><td>2018/2019</td><td>David Archer</td><td>55.00&#37</td></tr>
                 <tr><td>19</td><td>2017/2018</td><td>John Press</td><td>59.52&#37</td></tr>
@@ -134,10 +131,9 @@
                 <th>Season</th><th>Years</th><th>Winner</th><th>Greens Hit</th>
             </thead>
             <tbody>
-                <tr><td>25</td><td>2023/2024</td><td>Andrew Baldwin</td><td>73.81&#37</td></tr>
-                <tr><td>24</td><td>2022/2023</td><td>Paul Carter</td><td>45.83&#37</td></tr>
-                <tr><td>23</td><td>2021/2022</td><td>Paul Carter</td><td>45.83&#37</td></tr>
-                <tr><td>22</td><td>2020/2021</td><td>Jeff Colbrook</td><td>63.43&#37</td></tr>
+                <tr><td>24</td><td>2023/2024</td><td>Andrew Baldwin</td><td>73.81&#37</td></tr>
+                <tr><td>23</td><td>2022/2023</td><td>Paul Carter</td><td>45.83&#37</td></tr>
+                <tr><td>22</td><td>2020/2022</td><td>Jeff Colbrook</td><td>63.43&#37</td></tr>
                 <tr><td>21</td><td>2019/2020</td><td>Roy Dickens</td><td>60.32&#37</td></tr>
                 <tr><td>20</td><td>2018/2019</td><td>Chris Manning</td><td>72.22&#37</td></tr>
                 <tr><td>19</td><td>2017/2018</td><td>Andrew Benson</td><td>68.06&#37</td></tr>
@@ -172,10 +168,9 @@
                 <th>Season</th><th>Years</th><th>Winner</th><th>Putts</th>
             </thead>
             <tbody>
-                <tr><td>25</td><td>2023/2024</td><td>Robert Thompson</td><td>30.45</td></tr>
-                <tr><td>24</td><td>2022/2023</td><td>Robert Thompson</td><td>31.96</td></tr>
-                <tr><td>23</td><td>2021/2022</td><td>Robert Thompson</td><td>31.96</td></tr>
-                <tr><td>22</td><td>2020/2021</td><td>Alan Hopkins</td><td>31.67</td></tr>
+                <tr><td>24</td><td>2023/2024</td><td>Robert Thompson</td><td>30.45</td></tr>
+                <tr><td>23</td><td>2022/2023</td><td>Robert Thompson</td><td>31.96</td></tr>
+                <tr><td>22</td><td>2020/2022</td><td>Alan Hopkins</td><td>31.67</td></tr>
                 <tr><td>21</td><td>2019/2020</td><td>David Bingham</td><td>31.33</td></tr>
                 <tr><td>20</td><td>2018/2019</td><td>David Braithwaite</td><td>30.5</td></tr>
                 <tr><td>19</td><td>2017/2018</td><td>David Braithwaite</td><td>32.67</td></tr>
@@ -209,10 +204,9 @@
                 <th>Season</th><th>Years</th><th>Winner</th><th>Total </th>
             </thead> 
             <tbody>
-                <tr><td>25</td><td>2023/2024</td><td>Jeff Colbrook</td><td>55</td></tr>
-                <tr><td>24</td><td>2022/2023</td><td>Jeff Colbrook</td><td>72</td></tr>
-                <tr><td>23</td><td>2021/2022</td><td>Jeff Colbrook</td><td>72</td></tr>
-                <tr><td>22</td><td>2020/2021</td><td>David Rouse</td><td>39</td></tr>
+                <tr><td>24</td><td>2023/2024</td><td>Jeff Colbrook</td><td>55</td></tr>
+                <tr><td>23</td><td>2022/2023</td><td>Jeff Colbrook</td><td>72</td></tr>
+                <tr><td>22</td><td>2020/2022</td><td>David Rouse</td><td>39</td></tr>
                 <tr><td>21</td><td>2019/2020</td><td>David Rouse</td><td>38</td></tr>
                 <tr><td>20</td><td>2018/2019</td><td>David Rouse</td><td>67</td></tr>
                 <tr><td>19</td><td>2017/2018</td><td>David Rouse</td><td>44</td></tr>
@@ -247,10 +241,9 @@
                 <th>Season</th><th>Years</th><th>Winner</th><th>Avg Ferrets</th>
             </thead>
             <tbody>
-                <tr><td>25</td><td>2023/2024</td><td>David Rouse</td><td>4.6</td></tr>
-                <tr><td>24</td><td>2022/2023</td><td>Roy Dickens</td><td>3</td></tr>
-                <tr><td>23</td><td>2021/2022</td><td>Roy Dickens</td><td>3</td></tr>
-                <tr><td>22</td><td>2020/2021</td><td>David Bingham</td><td>3</td></tr>
+                <tr><td>24</td><td>2023/2024</td><td>David Rouse</td><td>4.6</td></tr>
+                <tr><td>23</td><td>2022/2023</td><td>Roy Dickens</td><td>3</td></tr>
+                <tr><td>22</td><td>2020/2022</td><td>David Bingham</td><td>3</td></tr>
                 <tr><td>21</td><td>2019/2020</td><td>Ian Edwards</td><td>4</td></tr>
                 <tr><td>20</td><td>2018/2019</td><td>Kevin Gallagher</td><td>4</td></tr>
                 <tr><td>19</td><td>2017/2018</td><td>Michael Trimmings</td><td>6</td></tr>


### PR DESCRIPTION
mga honour boards - displayed season 25, which is still on going. 
years 2020 and 2021 were one, season.